### PR TITLE
Update eclipse_summary_converter.py and README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 reservoir-simulation-tools
 ==========================
 
-Repository containing a few tools for working with output files from the Eclipse reservir simulation software
+Repository containing a few tools for working with output files from the Eclipse reservoir simulation software.
+
+Eclipse, originally developed by Exploration Consultants Limited, is currently owned by Schlumberger Information Solutions.
+
+https://en.wikipedia.org/wiki/ECLIPSE_(reservoir_simulator)
+http://www.software.slb.com/products/foundation/Pages/eclipse.aspx

--- a/python/eclipse_summary_converter.py
+++ b/python/eclipse_summary_converter.py
@@ -1,20 +1,24 @@
 '''
-Uses the 'ecl_summary' command found in the Ensambles ERT software package
-created by statoil to convert data from an eclipse summary file to a csv format.
-Requires both a *.UNSMRY and *.SMSPEC file to be present.
+Uses the `ecl_summary` command found in the `Ensemble based Reservoir Tool` - ERT 
+software package created by Statoil to convert data from an Eclipse Summary file 
+to a .CSV format. Requires both a *.UNSMRY and *.SMSPEC file to be present.
 
-https://github.com/Ensembles/ert
+ERT software repository:
+    https://github.com/Ensembles/ert
 '''
 
 from matplotlib import pyplot as plt
 #from __future__ import print_function
 import subprocess
+import sys
 import os
 
-def list_summary_files():
-    summary_files = subprocess.check_output(['find', '.', '-name', '*.UNSMRY'])
+def list_summary_files(path):
+    '''
+        List .UNSMRY files in `path` directory tree.
+    '''
+    summary_files = subprocess.check_output(['find', path, '-name', '*.UNSMRY'])
     summary_files = summary_files.rstrip('\n').split('\n')
-    #summary_files = filter(None, summary_files)
     # Removing ./ and .UNSMRY
     summary_files = [sumfile[2:-7] for sumfile in summary_files]
 
@@ -27,17 +31,22 @@ def list_summary_files():
     print '|-----------------------------------------------------------------|'
     return summary_files
 
-def get_file_name():
-    summary_files = list_summary_files()
+def get_file_name(summary_files):
+    '''
+        Get the user's chosen file from the files list.
+    '''
     input_file = raw_input('\nFilename or number: ')
     try:
         file_number = int(input_file)
         filename = summary_files[file_number]
-    except Exception:
-        filename = input_file
+    except (ValueError, IndexError):
+        filename = input_file if input_file in summary_files else None
     return filename
 
 def get_properties(filename):
+    '''
+        Run ecl_summary on the file to get properties.
+    '''
     proplist = subprocess.check_output(["ecl_summary", filename, "--list"])
     proplist = proplist.replace('\n', ' ')
     proplist = proplist.split(' ')
@@ -83,6 +92,12 @@ def save_to_csv(headers, valuelist, filename):
     f.close()
     print 'Successfully created csv file ' + output_filename
 
+try:
+    path = sys.argv[1]
+except IndexError:
+    path = os.getcwd()
+
+summary_files = list_summary_files()
 
 filename = get_file_name()  # Getting file from user input
 proplist = get_properties(filename)  # Generate list of properties in file

--- a/python/eclipse_summary_converter.py
+++ b/python/eclipse_summary_converter.py
@@ -7,13 +7,14 @@ https://github.com/Ensembles/ert
 '''
 
 from matplotlib import pyplot as plt
+#from __future__ import print_function
 import subprocess
+import os
 
 def list_summary_files():
     summary_files = subprocess.check_output(['find', '.', '-name', '*.UNSMRY'])
-    summary_files = summary_files.split('\n')
-    if summary_files[-1] == '':
-        summary_files.pop()  # Deleting empty element at end
+    summary_files = summary_files.rstrip('\n').split('\n')
+    #summary_files = filter(None, summary_files)
     # Removing ./ and .UNSMRY
     summary_files = [sumfile[2:-7] for sumfile in summary_files]
 
@@ -21,8 +22,8 @@ def list_summary_files():
     print '|-----------------------------------------------------------------|'
     print '| The following files are available in the active folder:         |'
     print '|-----------------------------------------------------------------|'
-    for i in range(len(summary_files)):
-        print '| (%i) %s' % (i, summary_files[i])
+    for index, item in enumerate(summary_files):
+        print '| ({}) {}'.format(index, item)
     print '|-----------------------------------------------------------------|'
     return summary_files
 
@@ -40,8 +41,7 @@ def get_properties(filename):
     proplist = subprocess.check_output(["ecl_summary", filename, "--list"])
     proplist = proplist.replace('\n', ' ')
     proplist = proplist.split(' ')
-    while '' in proplist:
-        proplist.remove('') # Remove emtystrings from list
+    proplist = filter(None, proplist)
     return proplist
 
 def get_valuestring(filename, proplist):


### PR DESCRIPTION
## README.md
- More detailed description 
## eclipse_summary_converter.py
- Added directory choice, defaults to current working directory.
- Untangled list_summary_files and get_file_name. Latter was calling the former.
- Narrowed exceptions in get_file_name.
- Program now takes an argument for the path to search files in.
- Made list_summary_files take the `path` argument to search for summary files elsewhere.
## TODO:
- make list_summary_files platform independant (get rid of `find`) using os module.
